### PR TITLE
feat(nx-cloud): setup nx workspace

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -15,7 +15,7 @@
     ],
     "sharedGlobals": ["{workspaceRoot}/.github/workflows/ci.yml"]
   },
-  "nxCloudAccessToken": "OTQ5YjUwN2UtYjlkYS00NWVmLWJiYTgtMTFiMGY0ZmU5ZGI0fHJlYWQtd3JpdGU=",
+  "nxCloudAccessToken": "NmEwYmI5MTktYzExZi00ODI1LThkMjYtODBjZTdiNDJmODU4fHJlYWQtd3JpdGU=",
   "plugins": [
     {
       "plugin": "@nx/webpack/plugin",


### PR DESCRIPTION
feat(nx-cloud): setup nx cloud workspace 

This commit set up Nx Cloud for your Nx workspace enabling distributed caching
and GitHub integration for fast CI and improved Developer Experience.

You can access your Nx Cloud workspace by going to 
https://cloud.nx.app/orgs/66ad306f14599249334cf9bc/workspaces/66ad3075fead966c576bc03a

**Note:** This commit attempts to maintain formatting of the nx.json, however you may need to correct formatting by running an nx format command and committing the changes.